### PR TITLE
Bugfix when table name is a keyword

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -146,7 +146,7 @@ class ORMPurger implements PurgerInterface
 		foreach($orderedTables as $tbl) {
 			if(($emptyFilterExpression||preg_match($filterExpr, $tbl)) && array_search($tbl, $this->excluded) === false){
 				if ($this->purgeMode === self::PURGE_MODE_DELETE) {
-					$connection->executeUpdate("DELETE FROM " . $tbl);
+					$connection->executeUpdate(sprintf("DELETE FROM `%s`", $tbl));
 				} else {
 					$connection->executeUpdate($platform->getTruncateTableSQL($tbl, true));
 				}


### PR DESCRIPTION
In Mysql, when table name is a keyword (`order` for example) it will give the error: 

```
An exception occurred while executing 'DELETE FROM order': 
SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'order' at line 1 
```
